### PR TITLE
Fix some reports + tune euclidian algo

### DIFF
--- a/src/base/Quantizer.cpp
+++ b/src/base/Quantizer.cpp
@@ -266,7 +266,7 @@ Quantizer::unquantize(EventSelection *selection) const
     Rosegarden::EventSelection::eventcontainer::iterator it
         = selection->getSegmentEvents().begin();
 
-    for (; it != selection->getSegmentEvents().end(); it++) {
+    for (; it != selection->getSegmentEvents().end(); ++it) {
 
 	if (m_target == RawEventData || m_target == NotationPrefix) {
 

--- a/src/base/figuration/FigurationSourceMap.cpp
+++ b/src/base/figuration/FigurationSourceMap.cpp
@@ -802,7 +802,7 @@ typedef std::vector<RelativeEvent *> RelativeEventVec;
 int higherPitch(Event *a, Event* b)
 {
     if (!a->has(BaseProperties::PITCH) ||
-        !a->has(BaseProperties::PITCH)) {
+        !b->has(BaseProperties::PITCH)) {
         throw Exception("Shouldn't get a note that has no pitch.");
     }
 

--- a/src/document/io/LilyPondExporter.h
+++ b/src/document/io/LilyPondExporter.h
@@ -307,13 +307,13 @@ private:
     }
     int gcd(int a, int b) {
 	// Euclid's algorithm to find the greatest common divisor
-	while ( 1 ) {
-	    int r = a % b;
-	    if ( r == 0 )
-		return (b == 0 ? 1 : b);
-	    a = b;
-	    b = r; 
+        int t = 0;
+	while ( b != 0) {
+	    t = b;
+            b = a % b;
+            a = t;
 	}
+        return a;
     }
 };
 

--- a/src/document/io/MusicXmlExportHelper.cpp
+++ b/src/document/io/MusicXmlExportHelper.cpp
@@ -1477,7 +1477,7 @@ MusicXmlExportHelper::retrieve(bool direction, timeT time)
         }
     }
     for (std::vector<std::vector<SimpleQueue>::iterator>::iterator i = toErase.begin();
-         i != toErase.end(); i++) {
+         i != toErase.end(); ++i) {
         tmp_queue.erase(*i);
     }
 

--- a/src/gui/studio/AudioMixerWindow.cpp
+++ b/src/gui/studio/AudioMixerWindow.cpp
@@ -1429,7 +1429,7 @@ AudioMixerWindow::slotSetSubmasterCountFromAction()
         if (count + 1 < current) {
 
             BussList::iterator it = busses.end();
-            it--;  // Now this actually points to something
+            --it;  // Now this actually points to something
 
             while (count + 1 < current--) {
                 m_studio->removeBuss((*it--)->getId());
@@ -1438,7 +1438,7 @@ AudioMixerWindow::slotSetSubmasterCountFromAction()
         } else {
 
             BussList::iterator it = busses.end();
-            it--;
+            --it;
             unsigned int lastId = (*it)->getId();
 
             while (count + 1 > current++) {

--- a/src/sound/AlsaDriver.cpp
+++ b/src/sound/AlsaDriver.cpp
@@ -5327,6 +5327,7 @@ AlsaDriver::getAlsaModuleVersionString()
     if (v) {
         char buf[256];
         if (fgets(buf, 256, v) == NULL) {
+            fclose(v);
             return "(unknown)"; /* check fgets result */
         }
         fclose(v);
@@ -5357,6 +5358,7 @@ AlsaDriver::getKernelVersionString()
     if (v) {
         char buf[256];
         if (fgets(buf, 256, v) == NULL) {
+            fclose(v);
             return "(unknown)"; /* check fgets result */
         }
         fclose(v);

--- a/src/sound/RIFFAudioFile.cpp
+++ b/src/sound/RIFFAudioFile.cpp
@@ -590,6 +590,7 @@ RIFFAudioFile::identifySubType(const QString &filename)
         type = UNKNOWN;
 
     testFile->close();
+    delete testFile;
     delete [] bytes;
 
     return type;


### PR DESCRIPTION
Euclidian algo:
Following cppcheck reports[src/document/io/LilyPondExporter.h:313] -> [src/document/io/LilyPondExporter.h:311]: (warning) Either the condition 'b==0' is redundant or there is division by zero at line 311.
I took example of https://en.wikipedia.org/wiki/Euclidean_algorithm#Implementations

Fix cppcheck reports:
[src/base/figuration/FigurationSourceMap.cpp:804] -> [src/base/figuration/FigurationSourceMap.cpp:804]: (style) Same expression on both sides of '||'
[src/base/Quantizer.cpp:269]: (performance) Prefer prefix ++/-- operators for non-primitive types.
[src/document/io/MusicXmlExportHelper.cpp:1480]: (performance) Prefer prefix ++/-- operators for non-primitive types.
[src/gui/studio/AudioMixerWindow.cpp:1432]: (performance) Prefer prefix ++/-- operators for non-primitive types.
[src/gui/studio/AudioMixerWindow.cpp:1441]: (performance) Prefer prefix ++/-- operators for non-primitive types.
[src/sound/AlsaDriver.cpp:5330]: (error) Resource leak: v
[src/sound/AlsaDriver.cpp:5360]: (error) Resource leak: v
[src/sound/RIFFAudioFile.cpp:595]: (error) Memory leak: testFile