### PR TITLE
Feature layer improvement

### DIFF
--- a/src/base/Composition.cpp
+++ b/src/base/Composition.cpp
@@ -281,9 +281,6 @@ Composition::weakAddSegment(Segment *segment)
     if (!segment) return end();
     clearVoiceCaches();
     
-    RG_DEBUG << "weakAddSegment adding segment with id" <<
-        segment->getRuntimeId();
-
     iterator res = m_segments.insert(segment);
     segment->setComposition(this);
 
@@ -2478,13 +2475,13 @@ Composition::detachMarker(Rosegarden::Marker *marker)
 }
 
 Segment*
-Composition::getSegmentByBrand(const QString& brand) const
+Composition::getSegmentByMarking(const QString& marking) const
 {
     for (SegmentMultiSet::const_iterator i = m_segments.begin();
          i != m_segments.end(); ++i) {
         
         Segment* s = *i;
-        if (s->getBrand() == brand) {
+        if (s->getMarking() == marking) {
             return s;
         }
     }

--- a/src/base/Composition.cpp
+++ b/src/base/Composition.cpp
@@ -281,6 +281,9 @@ Composition::weakAddSegment(Segment *segment)
     if (!segment) return end();
     clearVoiceCaches();
     
+    RG_DEBUG << "weakAddSegment adding segment with id" <<
+        segment->getRuntimeId();
+
     iterator res = m_segments.insert(segment);
     segment->setComposition(this);
 
@@ -2472,6 +2475,20 @@ Composition::detachMarker(Rosegarden::Marker *marker)
     }
 
     return false;
+}
+
+Segment*
+Composition::getSegmentByBrand(const QString& brand) const
+{
+    for (SegmentMultiSet::const_iterator i = m_segments.begin();
+         i != m_segments.end(); ++i) {
+        
+        Segment* s = *i;
+        if (s->getBrand() == brand) {
+            return s;
+        }
+    }
+    return nullptr;
 }
 
 #if 0

--- a/src/base/Composition.h
+++ b/src/base/Composition.h
@@ -241,6 +241,8 @@ public:
     SegmentMultiSet& getSegments() { return m_segments; }
     const SegmentMultiSet& getSegments() const { return m_segments; }
 
+    Segment* getSegmentByBrand(const QString& label) const;
+
     unsigned int getNbSegments() const { return m_segments.size(); }
 
     /**

--- a/src/base/Composition.h
+++ b/src/base/Composition.h
@@ -241,7 +241,7 @@ public:
     SegmentMultiSet& getSegments() { return m_segments; }
     const SegmentMultiSet& getSegments() const { return m_segments; }
 
-    Segment* getSegmentByBrand(const QString& label) const;
+    Segment* getSegmentByMarking(const QString& Marking) const;
 
     unsigned int getNbSegments() const { return m_segments.size(); }
 

--- a/src/base/Event.cpp
+++ b/src/base/Event.cpp
@@ -406,6 +406,14 @@ Event::getStorageSize() const
 }
 
 bool
+Event::isCopyOf(const Event &e)
+{
+    if (&e == this) return true;
+    if (e.m_data == m_data) return true;
+    return false;
+}
+
+bool
 operator<(const Event &a, const Event &b)
 {
     timeT at = a.getAbsoluteTime();

--- a/src/base/Event.h
+++ b/src/base/Event.h
@@ -209,6 +209,9 @@ public:
                          getNotationDuration());
     }
 
+    // check if the events are copies
+    bool isCopyOf(const Event &e);
+
     friend bool operator<(const Event&, const Event&);
 
     /// Type of the Event (E.g. Note, Accidental, Key, etc...)

--- a/src/base/Segment.cpp
+++ b/src/base/Segment.cpp
@@ -1730,6 +1730,20 @@ getCompositionSegments()
     return composition->getSegments();
 }
 
+void
+Segment::addObserver(SegmentObserver *obs)
+{
+    RG_DEBUG << "addObserver" << this << obs;
+    m_observers.push_back(obs);
+}
+
+void
+Segment::removeObserver(SegmentObserver *obs)
+{
+    RG_DEBUG << "removeObserver" << this << obs;
+    m_observers.remove(obs);
+}
+
 SegmentHelper::~SegmentHelper() { }
 
 

--- a/src/base/Segment.cpp
+++ b/src/base/Segment.cpp
@@ -87,6 +87,7 @@ Segment::Segment(SegmentType segmentType, timeT startTime) :
     m_verse(0),
     m_forNotation(true)
 {
+    RG_DEBUG << "ctor" << this;
 }
 
 Segment::Segment(const Segment &segment):
@@ -133,6 +134,7 @@ Segment::Segment(const Segment &segment):
     m_verseCount(-1),   // -1 => computation needed
     m_verse(0)   // Needs a global recomputation on the whole composition
 {
+    RG_DEBUG << "cctor" << this;
     for (const_iterator it = segment.begin();
          it != segment.end(); ++it) {
         insert(new Event(**it));
@@ -154,6 +156,7 @@ Segment::cloneImpl() const
 
 Segment::~Segment()
 {
+    RG_DEBUG << "dtor" << this;
     if (!m_observers.empty()) {
         RG_WARNING << "dtor: Warning: " << m_observers.size() << " observers still extant";
         RG_WARNING << "Observers are:";

--- a/src/base/Segment.cpp
+++ b/src/base/Segment.cpp
@@ -242,13 +242,6 @@ Segment::setMarking(const QString& m, Composition* comp)
 }
 
 void
-Segment::dumpSegment() const
-{
-    RG_DEBUG << *this;
-}
-
-
-void
 Segment::setTmp() {
     m_isTmp = true;
     setGreyOut();

--- a/src/base/Segment.cpp
+++ b/src/base/Segment.cpp
@@ -233,10 +233,20 @@ Segment::setMarking(const QString& m, Composition* comp)
     if (m != "") {
         // remove old marking
         Segment* oldSeg = comp->getSegmentByMarking(m);
-        if (oldSeg) oldSeg->setMarking("", comp);
+        while (oldSeg) {
+            oldSeg->setMarking("", comp);
+            oldSeg = comp->getSegmentByMarking(m);
+        }
     }
     m_marking = m;
 }
+
+void
+Segment::dumpSegment() const
+{
+    RG_DEBUG << *this;
+}
+
 
 void
 Segment::setTmp() {

--- a/src/base/Segment.cpp
+++ b/src/base/Segment.cpp
@@ -218,20 +218,20 @@ Segment::getForNotation() const {
 }
 
 QString
-Segment::getBrand() const
+Segment::getMarking() const
 {
-    return m_brand;
+    return m_marking;
 }
 
 void
-Segment::setBrand(const QString& b)
+Segment::setMarking(const QString& m, Composition* comp)
 {
-    if (b != "") {
-        // remove old brand
-        Segment* oldSeg = m_composition->getSegmentByBrand(b);
-        oldSeg->setBrand("");
+    if (m != "") {
+        // remove old marking
+        Segment* oldSeg = comp->getSegmentByMarking(m);
+        if (oldSeg) oldSeg->setMarking("", comp);
     }
-    m_brand = b;
+    m_marking = m;
 }
 
 void

--- a/src/base/Segment.cpp
+++ b/src/base/Segment.cpp
@@ -14,6 +14,7 @@
 */
 
 #define RG_MODULE_STRING "[Segment]"
+#define RG_NO_DEBUG_PRINT 1
 
 #include "base/Segment.h"
 #include "base/NotationTypes.h"

--- a/src/base/Segment.cpp
+++ b/src/base/Segment.cpp
@@ -217,6 +217,23 @@ Segment::getForNotation() const {
     return m_forNotation;
 }
 
+QString
+Segment::getBrand() const
+{
+    return m_brand;
+}
+
+void
+Segment::setBrand(const QString& b)
+{
+    if (b != "") {
+        // remove old brand
+        Segment* oldSeg = m_composition->getSegmentByBrand(b);
+        oldSeg->setBrand("");
+    }
+    m_brand = b;
+}
+
 void
 Segment::setTmp() {
     m_isTmp = true;

--- a/src/base/Segment.h
+++ b/src/base/Segment.h
@@ -898,10 +898,10 @@ public:
      */
     bool getForNotation() const;
 
-    /// get and set brand. Setting a brand removes the brand from any
+    /// get and set marking. Setting a marking removes the marking from any
     /// outher segments
-    QString getBrand() const;
-    void setBrand(const QString& b);
+    QString getMarking() const;
+    void setMarking(const QString& m, Composition* comp);
 
 private:
     void checkInsertAsClefKey(Event *e) const;
@@ -960,7 +960,7 @@ private:
     //
     EventRulerList                m_eventRulerList;
 
-    QString m_brand;
+    QString m_marking;
 
 private: // stuff to support SegmentObservers
 

--- a/src/base/Segment.h
+++ b/src/base/Segment.h
@@ -745,8 +745,8 @@ public:
     // Get the segments in the current composition.
     static SegmentMultiSet& getCompositionSegments();
     
-    void  addObserver(SegmentObserver *obs) { m_observers.push_back(obs); }
-    void removeObserver(SegmentObserver *obs) { m_observers.remove(obs); }
+    void  addObserver(SegmentObserver *obs);
+    void removeObserver(SegmentObserver *obs);
 
     // List of visible EventRulers attached to this segment
     //

--- a/src/base/Segment.h
+++ b/src/base/Segment.h
@@ -903,9 +903,6 @@ public:
     QString getMarking() const;
     void setMarking(const QString& m, Composition* comp);
 
-    // for debug
-    void dumpSegment() const;
-
 private:
     void checkInsertAsClefKey(Event *e) const;
 

--- a/src/base/Segment.h
+++ b/src/base/Segment.h
@@ -903,6 +903,9 @@ public:
     QString getMarking() const;
     void setMarking(const QString& m, Composition* comp);
 
+    // for debug
+    void dumpSegment() const;
+
 private:
     void checkInsertAsClefKey(Event *e) const;
 

--- a/src/base/Segment.h
+++ b/src/base/Segment.h
@@ -898,6 +898,11 @@ public:
      */
     bool getForNotation() const;
 
+    /// get and set brand. Setting a brand removes the brand from any
+    /// outher segments
+    QString getBrand() const;
+    void setBrand(const QString& b);
+
 private:
     void checkInsertAsClefKey(Event *e) const;
 
@@ -954,6 +959,8 @@ private:
     // EventRulers currently selected as visible on this segment
     //
     EventRulerList                m_eventRulerList;
+
+    QString m_brand;
 
 private: // stuff to support SegmentObservers
 

--- a/src/base/SegmentNotationHelper.cpp
+++ b/src/base/SegmentNotationHelper.cpp
@@ -15,7 +15,7 @@
 
 #define RG_MODULE_STRING "[SegmentNotationHelper]"
 // Turn off all debugging here.
-//#define RG_NO_DEBUG_PRINT
+#define RG_NO_DEBUG_PRINT
 
 #include "SegmentNotationHelper.h"
 #include "base/NotationTypes.h"
@@ -852,8 +852,13 @@ SegmentNotationHelper::insertNote(timeT absoluteTime, Note note, int pitch,
 Segment::iterator
 SegmentNotationHelper::insertNote(Event *modelEvent)
 {
+    RG_DEBUG << "insertNote";
+    RG_DEBUG << *modelEvent;
+
     timeT absoluteTime = modelEvent->getAbsoluteTime();
     iterator i = segment().findNearestTime(absoluteTime);
+
+    RG_DEBUG << "absoluteTime" << absoluteTime;
 
     // If our insertion time doesn't match up precisely with any
     // existing event, and if we're inserting over a rest, split the
@@ -873,6 +878,7 @@ SegmentNotationHelper::insertNote(Event *modelEvent)
             (*i)->get<Int>(BEAMED_GROUP_UNTUPLED_COUNT);
     }
 
+    RG_DEBUG << "duration" << duration;
     //!!! Deal with end-of-bar issues!
 
     return insertSomething(i, duration, modelEvent, false);

--- a/src/base/Selection.cpp
+++ b/src/base/Selection.cpp
@@ -13,6 +13,8 @@
     COPYING included with this distribution for more information.
 */
 
+#define RG_MODULE_STRING "[EventSelection]"
+
 #include "Selection.h"
 #include "base/Segment.h"
 #include "SegmentNotationHelper.h"
@@ -28,6 +30,7 @@ EventSelection::EventSelection(Segment& t) :
     m_endTime(0),
     m_haveRealStartTime(false)
 {
+    RG_DEBUG << "EventSelection ctor 1" << this;
     t.addObserver(this);
 }
 
@@ -37,6 +40,7 @@ EventSelection::EventSelection(Segment& t, timeT beginTime, timeT endTime, bool 
     m_endTime(0),
     m_haveRealStartTime(false)
 {
+    RG_DEBUG << "EventSelection ctor 2" << this;
     t.addObserver(this);
 
     Segment::iterator i = t.findTime(beginTime);
@@ -82,11 +86,13 @@ EventSelection::EventSelection(const EventSelection &sel) :
     m_endTime(sel.m_endTime),
     m_haveRealStartTime(sel.m_haveRealStartTime)
 {
+    RG_DEBUG << "EventSelection copy ctor" << this;
     m_originalSegment.addObserver(this);
 }
 
 EventSelection::~EventSelection()
 {
+    RG_DEBUG << "EventSelection dtor" << this;
     if (!m_observers.empty()) {
         // Notify observers of deconstruction
         for (ObserverSet::const_iterator i = m_observers.begin(); i != m_observers.end(); ++i) {

--- a/src/base/Selection.cpp
+++ b/src/base/Selection.cpp
@@ -14,6 +14,7 @@
 */
 
 #define RG_MODULE_STRING "[EventSelection]"
+#define RG_NO_DEBUG_PRINT 1
 
 #include "Selection.h"
 #include "base/Segment.h"

--- a/src/commands/edit/PasteEventsCommand.cpp
+++ b/src/commands/edit/PasteEventsCommand.cpp
@@ -65,6 +65,36 @@ PasteEventsCommand::PasteEventsCommand(Segment &segment,
 }
 
 PasteEventsCommand::PasteEventsCommand(Segment &segment,
+                                       const QString& brand,
+                                       Clipboard *clipboard,
+                                       timeT,
+                                       PasteType pasteType,
+                                       Composition& comp) :
+    BasicCommand(getGlobalName(), brand, &comp),
+    m_relayoutEndTime(getEndTime()),
+    m_clipboard(new Clipboard(*clipboard)),
+    m_pasteType(pasteType),
+    m_pastedEvents(segment)
+{
+    if (pasteType != OpenAndPaste) {
+
+        // paste clef or key -> relayout to end
+
+        if (clipboard->isSingleSegment()) {
+
+            Segment *s(clipboard->getSingleSegment());
+            for (Segment::iterator i = s->begin(); i != s->end(); ++i) {
+                if ((*i)->isa(Clef::EventType) ||
+                    (*i)->isa(Key::EventType)) {
+                    m_relayoutEndTime = s->getEndTime();
+                    break;
+                }
+            }
+        }
+    }
+}
+
+PasteEventsCommand::PasteEventsCommand(Segment &segment,
                                        Clipboard *clipboard,
                                        timeT pasteTime,
                                        timeT pasteEndTime,
@@ -74,7 +104,8 @@ PasteEventsCommand::PasteEventsCommand(Segment &segment,
     m_clipboard(new Clipboard(*clipboard)),
     m_pasteType(pasteType),
     m_pastedEvents(segment)
-{}
+{
+}
 
 PasteEventsCommand::~PasteEventsCommand()
 {

--- a/src/commands/edit/PasteEventsCommand.cpp
+++ b/src/commands/edit/PasteEventsCommand.cpp
@@ -65,12 +65,12 @@ PasteEventsCommand::PasteEventsCommand(Segment &segment,
 }
 
 PasteEventsCommand::PasteEventsCommand(Segment &segment,
-                                       const QString& brand,
+                                       const QString& marking,
                                        Clipboard *clipboard,
-                                       timeT,
+                                       timeT pasteTime,
                                        PasteType pasteType,
                                        Composition& comp) :
-    BasicCommand(getGlobalName(), brand, &comp),
+    BasicCommand(getGlobalName(), pasteTime, marking, &comp),
     m_relayoutEndTime(getEndTime()),
     m_clipboard(new Clipboard(*clipboard)),
     m_pasteType(pasteType),

--- a/src/commands/edit/PasteEventsCommand.cpp
+++ b/src/commands/edit/PasteEventsCommand.cpp
@@ -235,11 +235,13 @@ PasteEventsCommand::modifySegment()
             m_pastedEvents = new EventContainer;
         }
 
-    EventSelection pastedEvents(*m_segment);
-    for (EventContainer::iterator i = m_pastedEvents->begin();
-	 i != m_pastedEvents->end(); ++i) {
-        pastedEvents.addEvent(*i);
-    }
+    EventSelection pastedEvents(*m_segment); // getSegment()
+    //    for (EventContainer::iterator i = m_pastedEvents->begin();
+    //	 i != m_pastedEvents->end(); ++i) {
+        //pastedEvents.addEvent(*i);
+    //}
+
+    RG_DEBUG << "m_pastedEvents size" << m_pastedEvents->size();
 
     if (!m_clipboard->isSingleSegment())
         return ;
@@ -358,6 +360,7 @@ PasteEventsCommand::modifySegment()
             }
         }
 
+        *m_pastedEvents = pastedEvents.getSegmentEvents();
         return ;
 
     case MatrixOverlay:
@@ -393,6 +396,7 @@ PasteEventsCommand::modifySegment()
 
         destination->normalizeRests(pasteTime, endTime);
 
+        *m_pastedEvents = pastedEvents.getSegmentEvents();
         return ;
     }
 
@@ -410,6 +414,7 @@ PasteEventsCommand::modifySegment()
     }
 
     destination->normalizeRests(pasteTime, pasteTime + duration);
+    *m_pastedEvents = pastedEvents.getSegmentEvents();
 }
 
 }

--- a/src/commands/edit/PasteEventsCommand.cpp
+++ b/src/commands/edit/PasteEventsCommand.cpp
@@ -16,6 +16,7 @@
 */
 
 #define RG_MODULE_STRING "[PasteEventsCommand]"
+#define RG_NO_DEBUG_PRINT 1
 
 #include "PasteEventsCommand.h"
 

--- a/src/commands/edit/PasteEventsCommand.cpp
+++ b/src/commands/edit/PasteEventsCommand.cpp
@@ -16,7 +16,7 @@
 */
 
 #define RG_MODULE_STRING "[PasteEventsCommand]"
-//#define RG_NO_DEBUG_PRINT 1
+#define RG_NO_DEBUG_PRINT 1
 
 #include "PasteEventsCommand.h"
 
@@ -224,7 +224,7 @@ PasteEventsCommand::isPossible()
 void
 PasteEventsCommand::modifySegment()
 {
-    RG_DEBUG << "PasteEventsCommand::modifySegment" << m_segment;
+    RG_DEBUG << "PasteEventsCommand::modifySegment" << getSegment();
 
     if (!m_clipboard->isSingleSegment())
         return ;
@@ -232,12 +232,23 @@ PasteEventsCommand::modifySegment()
     Segment *source = m_clipboard->getSingleSegment();
     Segment *destination(&getSegment());
 
+    RG_DEBUG << "segment source";
+    source->dumpSegment();
+    RG_DEBUG << "segment source end";
+    RG_DEBUG << "segment destination";
+    destination->dumpSegment();
+    RG_DEBUG << "segment destination end";
+
     timeT destEndTime = destination->getEndTime();
     timeT pasteTime = std::max(getStartTime(), destination->getStartTime());
     timeT origin = source->getStartTime();
     timeT duration = source->getEndTime() - origin;
 
+    RG_DEBUG << "pasteTime" << pasteTime << "origin" << origin;
+
     SegmentNotationHelper helper(*destination);
+    bool possible = helper.removeRests(pasteTime, duration, true);
+    if (! possible) RG_WARNING << "pasting when not possible";
 
     RG_DEBUG << "PasteEventsCommand::modifySegment() : paste type = "
     << m_pasteType << " - pasteTime = "

--- a/src/commands/edit/PasteEventsCommand.cpp
+++ b/src/commands/edit/PasteEventsCommand.cpp
@@ -16,7 +16,7 @@
 */
 
 #define RG_MODULE_STRING "[PasteEventsCommand]"
-#define RG_NO_DEBUG_PRINT 1
+//#define RG_NO_DEBUG_PRINT 1
 
 #include "PasteEventsCommand.h"
 
@@ -44,8 +44,7 @@ PasteEventsCommand::PasteEventsCommand(Segment &segment,
                  getEffectiveEndTime(segment, clipboard, pasteTime)),
     m_relayoutEndTime(getEndTime()),
     m_clipboard(new Clipboard(*clipboard)),
-    m_pasteType(pasteType),
-    m_pastedEvents(new EventContainer)
+    m_pasteType(pasteType)
 {
     if (pasteType != OpenAndPaste) {
 
@@ -73,8 +72,7 @@ PasteEventsCommand::PasteEventsCommand(const QString& marking,
     BasicCommand(getGlobalName(), pasteTime, marking, &comp),
     m_relayoutEndTime(getEndTime()),
     m_clipboard(new Clipboard(*clipboard)),
-    m_pasteType(pasteType),
-    m_pastedEvents(nullptr)
+    m_pasteType(pasteType)
 {
     if (pasteType != OpenAndPaste) {
 
@@ -102,15 +100,13 @@ PasteEventsCommand::PasteEventsCommand(Segment &segment,
     BasicCommand(getGlobalName(), segment, pasteTime, pasteEndTime),
     m_relayoutEndTime(getEndTime()),
     m_clipboard(new Clipboard(*clipboard)),
-    m_pasteType(pasteType),
-    m_pastedEvents(new EventContainer)
+    m_pasteType(pasteType)
 {
 }
 
 PasteEventsCommand::~PasteEventsCommand()
 {
     delete m_clipboard;
-    if (m_pastedEvents) delete m_pastedEvents;
 }
 
 PasteEventsCommand::PasteTypeMap
@@ -229,19 +225,8 @@ void
 PasteEventsCommand::modifySegment()
 {
     RG_DEBUG << "PasteEventsCommand::modifySegment" << m_segment;
-    requireSegment();
-    if (!m_pastedEvents)
-        {
-            m_pastedEvents = new EventContainer;
-        }
 
-    EventSelection pastedEvents(*m_segment); // getSegment()
-    //    for (EventContainer::iterator i = m_pastedEvents->begin();
-    //	 i != m_pastedEvents->end(); ++i) {
-        //pastedEvents.addEvent(*i);
-    //}
-
-    RG_DEBUG << "m_pastedEvents size" << m_pastedEvents->size();
+    EventSelection pastedEvents(getSegment());
 
     if (!m_clipboard->isSingleSegment())
         return ;
@@ -360,7 +345,6 @@ PasteEventsCommand::modifySegment()
             }
         }
 
-        *m_pastedEvents = pastedEvents.getSegmentEvents();
         return ;
 
     case MatrixOverlay:
@@ -396,7 +380,6 @@ PasteEventsCommand::modifySegment()
 
         destination->normalizeRests(pasteTime, endTime);
 
-        *m_pastedEvents = pastedEvents.getSegmentEvents();
         return ;
     }
 
@@ -414,7 +397,6 @@ PasteEventsCommand::modifySegment()
     }
 
     destination->normalizeRests(pasteTime, pasteTime + duration);
-    *m_pastedEvents = pastedEvents.getSegmentEvents();
 }
 
 }

--- a/src/commands/edit/PasteEventsCommand.cpp
+++ b/src/commands/edit/PasteEventsCommand.cpp
@@ -226,8 +226,6 @@ PasteEventsCommand::modifySegment()
 {
     RG_DEBUG << "PasteEventsCommand::modifySegment" << m_segment;
 
-    EventSelection pastedEvents(getSegment());
-
     if (!m_clipboard->isSingleSegment())
         return ;
 
@@ -313,7 +311,6 @@ PasteEventsCommand::modifySegment()
 
             for (size_t i = 0; i < copies.size(); ++i) {
                 destination->insert(copies[i]);
-                pastedEvents.addEvent(copies[i]);
             }
 
             endTime = std::min(destEndTime, destination->getBarEndForTime(endTime));
@@ -321,7 +318,7 @@ PasteEventsCommand::modifySegment()
             break;
         }
 
-    case NoteOverlay:
+    case NoteOverlay: {
         for (Segment::iterator i = source->begin(); i != source->end(); ++i) {
             if ((*i)->isa(Note::EventRestType)) {
                 continue;
@@ -335,17 +332,18 @@ PasteEventsCommand::modifySegment()
             }
 
             if ((*i)->isa(Note::EventType)) {
+                RG_DEBUG << "NoteOverlay insert" <<
+                    e->getNotationAbsoluteTime();
                 // e is model event: we retain ownership of it
-                Segment::iterator i = helper.insertNote(e);
+                helper.insertNote(e);
                 delete e;
-                if (i != destination->end()) pastedEvents.addEvent(*i);
             } else {
                 destination->insert(e);
-                pastedEvents.addEvent(e);
             }
         }
 
-        return ;
+        return;
+    }
 
     case MatrixOverlay:
 
@@ -370,7 +368,6 @@ PasteEventsCommand::modifySegment()
             }
 
             destination->insert(e);
-            pastedEvents.addEvent(e);
         }
 
         timeT endTime = pasteTime + duration;
@@ -393,7 +390,6 @@ PasteEventsCommand::modifySegment()
                                               <Int>(BEAMED_GROUP_ID)]);
         }
         destination->insert(e);
-        pastedEvents.addEvent(e);
     }
 
     destination->normalizeRests(pasteTime, pasteTime + duration);

--- a/src/commands/edit/PasteEventsCommand.cpp
+++ b/src/commands/edit/PasteEventsCommand.cpp
@@ -44,7 +44,7 @@ PasteEventsCommand::PasteEventsCommand(Segment &segment,
     m_relayoutEndTime(getEndTime()),
     m_clipboard(new Clipboard(*clipboard)),
     m_pasteType(pasteType),
-    m_pastedEvents(new EventSelection(segment))
+    m_pastedEvents(new EventContainer)
 {
     if (pasteType != OpenAndPaste) {
 
@@ -102,7 +102,7 @@ PasteEventsCommand::PasteEventsCommand(Segment &segment,
     m_relayoutEndTime(getEndTime()),
     m_clipboard(new Clipboard(*clipboard)),
     m_pasteType(pasteType),
-    m_pastedEvents(new EventSelection(segment))
+    m_pastedEvents(new EventContainer)
 {
 }
 
@@ -231,8 +231,14 @@ PasteEventsCommand::modifySegment()
     requireSegment();
     if (!m_pastedEvents)
         {
-            m_pastedEvents = new EventSelection(*m_segment);
+            m_pastedEvents = new EventContainer;
         }
+
+    EventSelection pastedEvents(*m_segment);
+    for (EventContainer::iterator i = m_pastedEvents->begin();
+	 i != m_pastedEvents->end(); ++i) {
+        pastedEvents.addEvent(*i);
+    }
 
     if (!m_clipboard->isSingleSegment())
         return ;
@@ -319,7 +325,7 @@ PasteEventsCommand::modifySegment()
 
             for (size_t i = 0; i < copies.size(); ++i) {
                 destination->insert(copies[i]);
-                m_pastedEvents->addEvent(copies[i]);
+                pastedEvents.addEvent(copies[i]);
             }
 
             endTime = std::min(destEndTime, destination->getBarEndForTime(endTime));
@@ -344,10 +350,10 @@ PasteEventsCommand::modifySegment()
                 // e is model event: we retain ownership of it
                 Segment::iterator i = helper.insertNote(e);
                 delete e;
-                if (i != destination->end()) m_pastedEvents->addEvent(*i);
+                if (i != destination->end()) pastedEvents.addEvent(*i);
             } else {
                 destination->insert(e);
-                m_pastedEvents->addEvent(e);
+                pastedEvents.addEvent(e);
             }
         }
 
@@ -376,7 +382,7 @@ PasteEventsCommand::modifySegment()
             }
 
             destination->insert(e);
-            m_pastedEvents->addEvent(e);
+            pastedEvents.addEvent(e);
         }
 
         timeT endTime = pasteTime + duration;
@@ -399,16 +405,10 @@ PasteEventsCommand::modifySegment()
                                               <Int>(BEAMED_GROUP_ID)]);
         }
         destination->insert(e);
-        m_pastedEvents->addEvent(e);
+        pastedEvents.addEvent(e);
     }
 
     destination->normalizeRests(pasteTime, pasteTime + duration);
-}
-
-EventSelection
-PasteEventsCommand::getPastedEvents()
-{
-    return *m_pastedEvents;
 }
 
 }

--- a/src/commands/edit/PasteEventsCommand.cpp
+++ b/src/commands/edit/PasteEventsCommand.cpp
@@ -227,9 +227,12 @@ PasteEventsCommand::isPossible()
 void
 PasteEventsCommand::modifySegment()
 {
-    RG_DEBUG << "PasteEventsCommand::modifySegment";
+    RG_DEBUG << "PasteEventsCommand::modifySegment" << m_segment;
     requireSegment();
-    m_pastedEvents = new EventSelection(*m_segment);
+    if (!m_pastedEvents)
+        {
+            m_pastedEvents = new EventSelection(*m_segment);
+        }
 
     if (!m_clipboard->isSingleSegment())
         return ;

--- a/src/commands/edit/PasteEventsCommand.cpp
+++ b/src/commands/edit/PasteEventsCommand.cpp
@@ -233,10 +233,10 @@ PasteEventsCommand::modifySegment()
     Segment *destination(&getSegment());
 
     RG_DEBUG << "segment source";
-    source->dumpSegment();
+    RG_DEBUG << *source;
     RG_DEBUG << "segment source end";
     RG_DEBUG << "segment destination";
-    destination->dumpSegment();
+    RG_DEBUG << *destination;
     RG_DEBUG << "segment destination end";
 
     timeT destEndTime = destination->getEndTime();
@@ -352,6 +352,10 @@ PasteEventsCommand::modifySegment()
                 destination->insert(e);
             }
         }
+
+        RG_DEBUG << "segment after modify";
+        RG_DEBUG << *destination;
+        RG_DEBUG << "segment after modify end";
 
         return;
     }

--- a/src/commands/edit/PasteEventsCommand.h
+++ b/src/commands/edit/PasteEventsCommand.h
@@ -67,8 +67,7 @@ public:
      * Construct a Paste command from a clipboard that already contains
      * the events to be pasted. Identify the segment by marking
      */
-    PasteEventsCommand(Segment &segment,
-                       const QString& marking,
+    PasteEventsCommand(const QString& marking,
                        Clipboard *clipboard,
                        timeT pasteTime,
                        PasteType pasteType,
@@ -108,7 +107,7 @@ protected:
     timeT m_relayoutEndTime;
     Clipboard *m_clipboard;
     PasteType m_pasteType;
-    EventSelection m_pastedEvents;
+    EventSelection *m_pastedEvents;
 };
 
 

--- a/src/commands/edit/PasteEventsCommand.h
+++ b/src/commands/edit/PasteEventsCommand.h
@@ -65,10 +65,10 @@ public:
 
     /**
      * Construct a Paste command from a clipboard that already contains
-     * the events to be pasted. Identify the segment by brand
+     * the events to be pasted. Identify the segment by marking
      */
     PasteEventsCommand(Segment &segment,
-                       const QString& brand,
+                       const QString& marking,
                        Clipboard *clipboard,
                        timeT pasteTime,
                        PasteType pasteType,

--- a/src/commands/edit/PasteEventsCommand.h
+++ b/src/commands/edit/PasteEventsCommand.h
@@ -105,7 +105,6 @@ protected:
     timeT m_relayoutEndTime;
     Clipboard *m_clipboard;
     PasteType m_pasteType;
-    EventContainer *m_pastedEvents;  // not needed
 };
 
 

--- a/src/commands/edit/PasteEventsCommand.h
+++ b/src/commands/edit/PasteEventsCommand.h
@@ -105,7 +105,7 @@ protected:
     timeT m_relayoutEndTime;
     Clipboard *m_clipboard;
     PasteType m_pasteType;
-    EventContainer *m_pastedEvents;
+    EventContainer *m_pastedEvents;  // not needed
 };
 
 

--- a/src/commands/edit/PasteEventsCommand.h
+++ b/src/commands/edit/PasteEventsCommand.h
@@ -64,6 +64,17 @@ public:
                        PasteType pasteType);
 
     /**
+     * Construct a Paste command from a clipboard that already contains
+     * the events to be pasted. Identify the segment by brand
+     */
+    PasteEventsCommand(Segment &segment,
+                       const QString& brand,
+                       Clipboard *clipboard,
+                       timeT pasteTime,
+                       PasteType pasteType,
+                       Composition& comp);
+
+    /**
      * Construct a Paste command from a clipboard that will contain
      * the events to be pasted by the time the Paste command is
      * executed, but might not do so yet.  This is necessary if the

--- a/src/commands/edit/PasteEventsCommand.h
+++ b/src/commands/edit/PasteEventsCommand.h
@@ -90,8 +90,6 @@ public:
 
     ~PasteEventsCommand() override;
 
-    EventSelection getPastedEvents();
-
     static QString getGlobalName() { return tr("&Paste"); }
 
     /// Determine whether this paste will succeed (without executing it yet)
@@ -107,7 +105,7 @@ protected:
     timeT m_relayoutEndTime;
     Clipboard *m_clipboard;
     PasteType m_pasteType;
-    EventSelection *m_pastedEvents;
+    EventContainer *m_pastedEvents;
 };
 
 

--- a/src/commands/notation/AdoptSegmentCommand.cpp
+++ b/src/commands/notation/AdoptSegmentCommand.cpp
@@ -15,9 +15,13 @@
     COPYING included with this distribution for more information.
 */
 
+#define RG_MODULE_STRING "[AdoptSegmentCommand]"
+#define RG_NO_DEBUG_PRINT 1
+
 #include "AdoptSegmentCommand.h"
 
 #include "gui/editors/notation/NotationView.h"
+#include "misc/Debug.h"
 
 #include <QString>
 
@@ -38,7 +42,9 @@ AdoptSegmentCommand(QString name, //
   m_inComposition(inComposition),
   m_comp(nullptr)
 {
-    QObject::connect(&view, SIGNAL(destroyed()), this, SLOT(viewDestroyed()));
+    RG_DEBUG << "ctor 1" << getName();
+    QObject::connect(&view, SIGNAL(destroyed()),
+                     this, SLOT(slotViewdestroyed()));
 }
 
 AdoptSegmentCommand::
@@ -58,7 +64,9 @@ AdoptSegmentCommand(QString name,
   m_segmentMarking(segmentMarking),
   m_comp(comp)
 {
-    QObject::connect(&view, SIGNAL(destroyed()), this, SLOT(viewDestroyed()));
+    RG_DEBUG << "ctor 2" << getName();
+    QObject::connect(&view, SIGNAL(destroyed()),
+                     this, SLOT(slotViewdestroyed()));
 }
   
 AdoptSegmentCommand::
@@ -71,11 +79,15 @@ AdoptSegmentCommand::
 }
 void
 AdoptSegmentCommand::slotViewdestroyed()
-{ m_viewDestroyed = true; }
+{
+    RG_DEBUG << "view destroyed";
+    m_viewDestroyed = true;
+}
 
 void
 AdoptSegmentCommand::execute()
 {
+    RG_DEBUG << "execute";
     if (m_into) { adopt(); }
     else { unadopt(); }
 }
@@ -83,6 +95,7 @@ AdoptSegmentCommand::execute()
 void
 AdoptSegmentCommand::unexecute()
 {
+    RG_DEBUG << "unexecute";
     if (m_into) { unadopt(); }
     else { adopt(); }
 }
@@ -90,8 +103,8 @@ AdoptSegmentCommand::unexecute()
 void
 AdoptSegmentCommand::adopt()
 {
-    requireSegment();
     if (m_viewDestroyed) { return; }
+    requireSegment();
     if (m_inComposition) {
         m_view.adoptCompositionSegment(m_segment);
     } else {

--- a/src/commands/notation/AdoptSegmentCommand.h
+++ b/src/commands/notation/AdoptSegmentCommand.h
@@ -31,9 +31,9 @@ class NotationView;
 // Needs to be a QObject so it can get a signal if view is destroyed.
 class AdoptSegmentCommand : public QObject, public NamedCommand
 {
-    Q_DECLARE_TR_FUNCTIONS(Rosegarden::AdoptSegmentCommand)
+    Q_OBJECT;
 
-public:
+ public:
     AdoptSegmentCommand(QString name,
                         NotationView &view,
                         Segment *segment,

--- a/src/commands/notation/AdoptSegmentCommand.h
+++ b/src/commands/notation/AdoptSegmentCommand.h
@@ -37,7 +37,16 @@ public:
     AdoptSegmentCommand(QString name,
                         NotationView &view,
                         Segment *segment,
-                        bool into = true);
+                        bool into = true,
+                        bool inComposition = false);
+
+    // Alternative constructor if segment does not exist at creation time
+    AdoptSegmentCommand(QString name,
+                        NotationView &view,
+                        const QString& segmentMarking,
+                        Composition* comp,
+                        bool into = true,
+                        bool inComposition = false);
     ~AdoptSegmentCommand() override;
 
 protected:
@@ -50,11 +59,19 @@ protected slots:
     void slotViewdestroyed();
     
  private:
+
+    void requireSegment();
+
     NotationView &m_view;
     Segment   *m_segment;
     const bool m_into;
     bool       m_detached;
     bool       m_viewDestroyed;
+    bool       m_inComposition;
+    QString    m_segmentMarking;
+
+    /// the composition
+    Composition *m_comp;
 };
  
 }

--- a/src/commands/segment/AddLayerCommand.cpp
+++ b/src/commands/segment/AddLayerCommand.cpp
@@ -56,7 +56,15 @@ AddLayerCommand::execute()
 { 
     if (!m_segment) return;
 
-    Segment *layer = new Segment();
+    if (m_detached) {
+        // the layer already exists - we just need to re-add it. Note
+        // - we have laready adjusted m_segment to point to the layer
+        m_composition.addSegment(m_segment);
+        return;
+    }
+
+    // create a new layer
+    Segment* layer = new Segment();
     layer->setMarking("Added Layer", &m_composition);
 
     layer->setTrack(m_segment->getTrack());

--- a/src/commands/segment/AddLayerCommand.cpp
+++ b/src/commands/segment/AddLayerCommand.cpp
@@ -15,9 +15,12 @@
     COPYING included with this distribution for more information.
 */
 
+#define RG_NO_DEBUG_PRINT 1
+#define RG_MODULE_STRING "[AddLayerCommand]"
 
 #include "AddLayerCommand.h"
 
+#include "misc/Debug.h"
 #include "base/Segment.h"
 #include "base/Composition.h"
 #include "base/Track.h"
@@ -60,11 +63,13 @@ AddLayerCommand::execute()
         // the layer already exists - we just need to re-add it. Note
         // - we have laready adjusted m_segment to point to the layer
         m_composition.addSegment(m_segment);
+        RG_DEBUG << "attaching segment" << m_segment;
         return;
     }
 
     // create a new layer
     Segment* layer = new Segment();
+    RG_DEBUG << "creating segment" << layer;
     layer->setMarking("Added Layer", &m_composition);
 
     layer->setTrack(m_segment->getTrack());

--- a/src/commands/segment/AddLayerCommand.cpp
+++ b/src/commands/segment/AddLayerCommand.cpp
@@ -57,7 +57,7 @@ AddLayerCommand::execute()
     if (!m_segment) return;
 
     Segment *layer = new Segment();
-    layer->setLabel("Added Layer");
+    layer->setMarking("Added Layer", &m_composition);
 
     layer->setTrack(m_segment->getTrack());
     layer->setStartTime(m_segment->getStartTime());

--- a/src/commands/segment/AddLayerCommand.cpp
+++ b/src/commands/segment/AddLayerCommand.cpp
@@ -57,6 +57,7 @@ AddLayerCommand::execute()
     if (!m_segment) return;
 
     Segment *layer = new Segment();
+    layer->setLabel("Added Layer");
 
     layer->setTrack(m_segment->getTrack());
     layer->setStartTime(m_segment->getStartTime());

--- a/src/commands/segment/AddLayerCommand.cpp
+++ b/src/commands/segment/AddLayerCommand.cpp
@@ -64,6 +64,9 @@ AddLayerCommand::execute()
         // - we have laready adjusted m_segment to point to the layer
         m_composition.addSegment(m_segment);
         RG_DEBUG << "attaching segment" << m_segment;
+        RG_DEBUG << "layer after attatch";
+        RG_DEBUG << *m_segment;
+        RG_DEBUG << "layer after attatch end";
         return;
     }
 
@@ -133,6 +136,9 @@ AddLayerCommand::execute()
     // asked
     m_segment = layer;
     m_detached = false;
+    RG_DEBUG << "layer after creation";
+    RG_DEBUG << *m_segment;
+    RG_DEBUG << "layer after creation end";
 }
 
 void
@@ -140,6 +146,10 @@ AddLayerCommand::unexecute()
 {
     m_composition.detachSegment(m_segment);
     m_detached = true;
+    RG_DEBUG << "layer after detatch";
+    RG_DEBUG << *m_segment;
+    RG_DEBUG << "layer after detatch end";
+
 }
 
 }

--- a/src/commands/segment/SegmentResizeFromStartCommand.cpp
+++ b/src/commands/segment/SegmentResizeFromStartCommand.cpp
@@ -15,6 +15,8 @@
     COPYING included with this distribution for more information.
 */
 
+#define RG_MODULE_STRING "[SegmentResizeFromStartCommand]"
+#define RG_NO_DEBUG_PRINT 1
 
 #include "SegmentResizeFromStartCommand.h"
 
@@ -35,6 +37,8 @@ SegmentResizeFromStartCommand::SegmentResizeFromStartCommand(Segment *s,
         m_oldStartTime(s->getStartTime()),
         m_newStartTime(time)
 {
+    RG_DEBUG << "ctor Segment start end" <<
+        s->getStartTime() << s->getEndTime();
     // nothing else
 }
 
@@ -46,6 +50,8 @@ SegmentResizeFromStartCommand::~SegmentResizeFromStartCommand()
 void
 SegmentResizeFromStartCommand::modifySegment()
 {
+    RG_DEBUG << "modifySegment start Segment start end" <<
+        m_segment->getStartTime() << m_segment->getEndTime();
     if (m_newStartTime < m_oldStartTime) {
         m_segment->fillWithRests(m_newStartTime, m_oldStartTime);
     } else {
@@ -72,6 +78,8 @@ SegmentResizeFromStartCommand::modifySegment()
             i = j;
         }
     }
+    RG_DEBUG << "modifySegment done Segment start end" <<
+        m_segment->getStartTime() << m_segment->getEndTime();
 }
 
 }

--- a/src/document/BasicCommand.cpp
+++ b/src/document/BasicCommand.cpp
@@ -330,6 +330,10 @@ BasicCommand::calculateModifiedStartEnd()
     // m_segment has modified events savedEvents has the original
     // unchanged segment events
     Segment::iterator j = m_savedEvents->begin();
+    if (j == m_savedEvents->end()) {
+        // all done
+        return;
+    }
     for (Segment::iterator i = m_segment->begin();
          i != m_segment->end(); ++i) {
         Event* segEvent = (*i);

--- a/src/document/BasicCommand.cpp
+++ b/src/document/BasicCommand.cpp
@@ -213,9 +213,9 @@ BasicCommand::copyTo(Rosegarden::Segment *events)
 
     for (Segment::iterator i = from; i != m_segment->end() && i != to; ++i) {
 
-       //RG_DEBUG << "copyTo(): Found event of type" << (*i)->getType() << "and duration" << (*i)->getDuration() << "at time" << (*i)->getAbsoluteTime();
+        RG_DEBUG << "copyTo(): Found event of type" << (*i)->getType() << "and duration" << (*i)->getDuration() << "at time" << (*i)->getAbsoluteTime();
 
-       events->insert(new Event(**i));
+        events->insert(new Event(**i));
     }
 }
    
@@ -228,11 +228,11 @@ BasicCommand::copyFrom(Rosegarden::Segment *events)
         m_endTime << ")";
 
     m_segment->erase(m_segment->findTime(m_startTime),
-                    m_segment->findTime(m_endTime));
+                     m_segment->findTime(m_endTime));
 
     for (Segment::iterator i = events->begin(); i != events->end(); ++i) {
 
-        //RG_DEBUG << "copyFrom(): Found event of type" << (*i)->getType() << "and duration" << (*i)->getDuration() << "at time" << (*i)->getAbsoluteTime();
+        RG_DEBUG << "copyFrom(): Found event of type" << (*i)->getType() << "and duration" << (*i)->getDuration() << "at time" << (*i)->getAbsoluteTime();
 
         m_segment->insert(new Event(**i));
     }
@@ -252,6 +252,7 @@ BasicCommand::requireSegment()
                "BasicCommand::requireSegment()",
                "Composition pointer is null.");
     m_segment = m_comp->getSegmentByMarking(m_segmentMarking);
+    RG_DEBUG << "requireSegment got segment" << m_segment;
     Q_ASSERT_X(&m_segment != nullptr,
                "BasicCommand::requireSegment()",
                "Segment pointer is null.");

--- a/src/document/BasicCommand.cpp
+++ b/src/document/BasicCommand.cpp
@@ -213,7 +213,7 @@ BasicCommand::unexecute()
     RG_DEBUG << "unexecute() begin...";
 
     if (m_redoEvents) {
-        copyTo(m_redoEvents);
+        copyTo(m_redoEvents, true);
         m_doBruteForceRedo = true;
     }
 

--- a/src/document/BasicCommand.cpp
+++ b/src/document/BasicCommand.cpp
@@ -338,12 +338,12 @@ BasicCommand::calculateModifiedStartEnd()
          i != m_segment->rend(); ++i) {
         Event* segEvent = (*i);
         Event* savedEvent = (*rj);
-        m_modifiedEventsEnd = segEvent->getAbsoluteTime() + 1;
         // are they the same ?
         if (!segEvent->isCopyOf(*savedEvent)) {
             // found a changed note
             break;
         }
+        m_modifiedEventsEnd = segEvent->getAbsoluteTime() - 1;
         ++rj;
         if (rj == m_savedEvents->rend()) {
             // all done

--- a/src/document/BasicCommand.cpp
+++ b/src/document/BasicCommand.cpp
@@ -259,6 +259,7 @@ BasicCommand::requireSegment()
     // adjust start time
     m_startTime = calculateStartTime(m_startTime, *m_segment);
     m_endTime = calculateEndTime(m_segment->getEndTime(), *m_segment);
+    if (m_endTime == m_startTime) ++m_endTime;
     m_savedEvents = new Segment(m_segment->getType(), m_startTime);
 }
   

--- a/src/document/BasicCommand.h
+++ b/src/document/BasicCommand.h
@@ -82,6 +82,13 @@ protected:
                  Segment &segment,
 		 Segment *redoEvents);
 
+    // Variant ctor to be used when the segment to be pasted to does
+    // not exist when the command is created
+    BasicCommand(const QString &name,
+                 const QString& segmentBrand,
+                 Composition* comp,
+                 bool bruteForceRedoRequired = false);
+
     virtual void modifySegment() = 0;
 
     virtual void beginExecute();
@@ -95,11 +102,17 @@ private:
     timeT calculateStartTime(timeT given, Segment &segment);
     timeT calculateEndTime(timeT given, Segment &segment);
 
+    /// if the segment is not set yet - get it from the segment id
+    void requireSegment();
+
     timeT m_startTime;
     timeT m_endTime;
 
-    /// The Segment that this command is being run against.
-    Segment &m_segment;
+    /// The Segment that this command is being run against.  This is a
+    /// pointer rather than a reference because it is possible to
+    /// create a command before the segment exists and set the segment
+    /// later
+    Segment *m_segment;
     /// Events from m_segment prior to executing the command.
     Segment m_savedEvents;
 
@@ -107,6 +120,13 @@ private:
     bool m_doBruteForceRedo;
     /// Events for redo, or for the "redoEvents" ctor.
     Segment *m_redoEvents;
+
+    /// The segment brand for delayed acces to segment
+    QString m_segmentBrand;
+
+    /// the composition
+    Composition *m_comp;
+
 };
 
 

--- a/src/document/BasicCommand.h
+++ b/src/document/BasicCommand.h
@@ -102,9 +102,17 @@ private:
     timeT calculateStartTime(timeT given, Segment &segment);
     timeT calculateEndTime(timeT given, Segment &segment);
 
+    /// if the segment is not set yet - get it from the segment marking
+    void requireSegment();
+
     timeT m_startTime;
     timeT m_endTime;
 
+    /// The Segment that this command is being run against.  This is a
+    /// pointer rather than a reference because it is possible to
+    /// create a command before the segment exists and set the segment
+    /// later
+    Segment *m_segment;
     /// Events from m_segment prior to executing the command.
     Segment *m_savedEvents;
 
@@ -119,16 +127,6 @@ private:
     /// the composition
     Composition *m_comp;
 
- protected:
-
-    /// if the segment is not set yet - get it from the segment marking
-    void requireSegment();
-
-    /// The Segment that this command is being run against.  This is a
-    /// pointer rather than a reference because it is possible to
-    /// create a command before the segment exists and set the segment
-    /// later
-    Segment *m_segment;
 };
 
 

--- a/src/document/BasicCommand.h
+++ b/src/document/BasicCommand.h
@@ -95,9 +95,9 @@ protected:
 
 private:
     /// Copy from m_segment to segment.
-    void copyTo(Segment *segment);
+    void copyTo(Segment *segment, bool wholeSegment = false);
     /// Copy from segment to m_segment replacing events in the time range.
-    void copyFrom(Segment *segment);
+    void copyFrom(Segment *segment, bool wholeSegment = false);
 
     timeT calculateStartTime(timeT given, Segment &segment);
     timeT calculateEndTime(timeT given, Segment &segment);

--- a/src/document/BasicCommand.h
+++ b/src/document/BasicCommand.h
@@ -134,6 +134,8 @@ private:
     timeT m_modifiedEventsStart;
     timeT m_modifiedEventsEnd;
 
+    timeT m_originalStartTime;
+
 };
 
 

--- a/src/document/BasicCommand.h
+++ b/src/document/BasicCommand.h
@@ -105,6 +105,9 @@ private:
     /// if the segment is not set yet - get it from the segment marking
     void requireSegment();
 
+    /// find out the range of Events modified by modifySegment
+    void calculateModifiedStartEnd();
+
     timeT m_startTime;
     timeT m_endTime;
 
@@ -126,6 +129,10 @@ private:
 
     /// the composition
     Composition *m_comp;
+
+    /// start and end of the range of events which are modified by modifySegment
+    timeT m_modifiedEventsStart;
+    timeT m_modifiedEventsEnd;
 
 };
 

--- a/src/document/BasicCommand.h
+++ b/src/document/BasicCommand.h
@@ -82,12 +82,12 @@ protected:
                  Segment &segment,
 		 Segment *redoEvents);
 
-    // Variant ctor to be used when the segment to be pasted to does
-    // not exist when the command is created
+    // Variant ctor to be used when the segment does not exist when
+    // the command is created.  Implies brute force redo false.
     BasicCommand(const QString &name,
-                 const QString& segmentBrand,
-                 Composition* comp,
-                 bool bruteForceRedoRequired = false);
+                 timeT start,
+                 const QString& segmentMarking,
+                 Composition* comp);
 
     virtual void modifySegment() = 0;
 
@@ -102,7 +102,7 @@ private:
     timeT calculateStartTime(timeT given, Segment &segment);
     timeT calculateEndTime(timeT given, Segment &segment);
 
-    /// if the segment is not set yet - get it from the segment id
+    /// if the segment is not set yet - get it from the segment marking
     void requireSegment();
 
     timeT m_startTime;
@@ -114,15 +114,15 @@ private:
     /// later
     Segment *m_segment;
     /// Events from m_segment prior to executing the command.
-    Segment m_savedEvents;
+    Segment *m_savedEvents;
 
     /// Redo or execute() will be using a list of events (m_redoEvents).
     bool m_doBruteForceRedo;
     /// Events for redo, or for the "redoEvents" ctor.
     Segment *m_redoEvents;
 
-    /// The segment brand for delayed acces to segment
-    QString m_segmentBrand;
+    /// The segment marking for delayed acces to segment
+    QString m_segmentMarking;
 
     /// the composition
     Composition *m_comp;

--- a/src/document/BasicCommand.h
+++ b/src/document/BasicCommand.h
@@ -102,17 +102,9 @@ private:
     timeT calculateStartTime(timeT given, Segment &segment);
     timeT calculateEndTime(timeT given, Segment &segment);
 
-    /// if the segment is not set yet - get it from the segment marking
-    void requireSegment();
-
     timeT m_startTime;
     timeT m_endTime;
 
-    /// The Segment that this command is being run against.  This is a
-    /// pointer rather than a reference because it is possible to
-    /// create a command before the segment exists and set the segment
-    /// later
-    Segment *m_segment;
     /// Events from m_segment prior to executing the command.
     Segment *m_savedEvents;
 
@@ -127,6 +119,16 @@ private:
     /// the composition
     Composition *m_comp;
 
+ protected:
+
+    /// if the segment is not set yet - get it from the segment marking
+    void requireSegment();
+
+    /// The Segment that this command is being run against.  This is a
+    /// pointer rather than a reference because it is possible to
+    /// create a command before the segment exists and set the segment
+    /// later
+    Segment *m_segment;
 };
 
 

--- a/src/gui/editors/notation/NotationScene.cpp
+++ b/src/gui/editors/notation/NotationScene.cpp
@@ -531,6 +531,19 @@ NotationScene::getNextStaffOnTrack()
 }
 
 NotationStaff *
+NotationScene::getStaffBySegmentBrand(const QString& brand) const
+{
+    for (unsigned int i=0; i<m_staffs.size(); ++i) {
+        NotationStaff* staff = m_staffs[i];
+        QString staffBrand = staff->getBrand();
+        if (staffBrand == brand) {
+            return staff;
+        }
+    }
+    return nullptr;
+}
+
+NotationStaff *
 NotationScene::getStaffbyTrackAndTime(const Track *track, timeT targetTime)
 {
     // Prepare a fallback: If this is the right track but no staff

--- a/src/gui/editors/notation/NotationScene.cpp
+++ b/src/gui/editors/notation/NotationScene.cpp
@@ -531,12 +531,12 @@ NotationScene::getNextStaffOnTrack()
 }
 
 NotationStaff *
-NotationScene::getStaffBySegmentBrand(const QString& brand) const
+NotationScene::getStaffBySegmentMarking(const QString& marking) const
 {
     for (unsigned int i=0; i<m_staffs.size(); ++i) {
         NotationStaff* staff = m_staffs[i];
-        QString staffBrand = staff->getBrand();
-        if (staffBrand == brand) {
+        QString staffMarking = staff->getMarking();
+        if (staffMarking == marking) {
             return staff;
         }
     }

--- a/src/gui/editors/notation/NotationScene.h
+++ b/src/gui/editors/notation/NotationScene.h
@@ -97,7 +97,7 @@ public:
     NotationStaff *getPriorStaffOnTrack();
     NotationStaff *getNextStaffOnTrack();
 
-    NotationStaff *getStaffBySegmentBrand(const QString& brand) const;
+    NotationStaff *getStaffBySegmentMarking(const QString& marking) const;
 
     NotationStaff *getStaffForSceneCoords(double x, int y) const;
 

--- a/src/gui/editors/notation/NotationScene.h
+++ b/src/gui/editors/notation/NotationScene.h
@@ -97,6 +97,8 @@ public:
     NotationStaff *getPriorStaffOnTrack();
     NotationStaff *getNextStaffOnTrack();
 
+    NotationStaff *getStaffBySegmentBrand(const QString& brand) const;
+
     NotationStaff *getStaffForSceneCoords(double x, int y) const;
 
     Segment *getCurrentSegment();

--- a/src/gui/editors/notation/NotationStaff.cpp
+++ b/src/gui/editors/notation/NotationStaff.cpp
@@ -96,7 +96,7 @@ NotationStaff::NotationStaff(NotationScene *scene, Segment *segment,
     m_hideRedundance(true),
     m_printPainter(nullptr),
     m_refreshStatusId(segment->getNewRefreshStatusId()),
-    m_segmentBrand(segment->getBrand())
+    m_segmentMarking(segment->getMarking())
 {
     QSettings settings;
     settings.beginGroup( NotationViewConfigGroup );

--- a/src/gui/editors/notation/NotationStaff.cpp
+++ b/src/gui/editors/notation/NotationStaff.cpp
@@ -95,7 +95,8 @@ NotationStaff::NotationStaff(NotationScene *scene, Segment *segment,
     m_showCollisions(true),
     m_hideRedundance(true),
     m_printPainter(nullptr),
-    m_refreshStatusId(segment->getNewRefreshStatusId())
+    m_refreshStatusId(segment->getNewRefreshStatusId()),
+    m_segmentBrand(segment->getBrand())
 {
     QSettings settings;
     settings.beginGroup( NotationViewConfigGroup );

--- a/src/gui/editors/notation/NotationStaff.h
+++ b/src/gui/editors/notation/NotationStaff.h
@@ -266,7 +266,7 @@ public:
 
     timeT getEndTime() const;
 
-    QString getBrand() const { return m_segmentBrand; }
+    QString getMarking() const { return m_segmentMarking; }
     
 protected:
 
@@ -372,7 +372,7 @@ protected:
 
     unsigned int m_refreshStatusId;
 
-    QString m_segmentBrand;
+    QString m_segmentMarking;
 };
 
 

--- a/src/gui/editors/notation/NotationStaff.h
+++ b/src/gui/editors/notation/NotationStaff.h
@@ -265,6 +265,8 @@ public:
     timeT getStartTime() const;
 
     timeT getEndTime() const;
+
+    QString getBrand() const { return m_segmentBrand; }
     
 protected:
 
@@ -369,6 +371,8 @@ protected:
     QPainter *m_printPainter;
 
     unsigned int m_refreshStatusId;
+
+    QString m_segmentBrand;
 };
 
 

--- a/src/gui/editors/notation/NotationView.cpp
+++ b/src/gui/editors/notation/NotationView.cpp
@@ -16,6 +16,7 @@
 */
 
 #define RG_MODULE_STRING "[NotationView]"
+#define RG_NO_DEBUG_PRINT 1
 
 #include "NotationView.h"
 

--- a/src/gui/editors/notation/NotationView.cpp
+++ b/src/gui/editors/notation/NotationView.cpp
@@ -5204,12 +5204,12 @@ NotationView::slotMagicLayer()
     // use overlay paste to avoid checking for space; paste to new
     // "layer" identify the layer with the segment marking.
     PasteEventsCommand::PasteType type = PasteEventsCommand::NoteOverlay;
-    macro->addCommand(new PasteEventsCommand(*currentSegment, "Added Layer", c,
+    macro->addCommand(new PasteEventsCommand("Added Layer", c,
                                              insertionTime, type, comp));
     
-    delete c;
-
     CommandHistory::getInstance()->addCommand(macro);
+
+    //delete c;
 
     // get the pointer to the segment we just created and add it to m_segments
     Segment* newLayer = comp.getSegmentByMarking("Added Layer");

--- a/src/gui/editors/notation/NotationView.cpp
+++ b/src/gui/editors/notation/NotationView.cpp
@@ -5203,7 +5203,7 @@ NotationView::slotMagicLayer()
     RG_DEBUG << "CopyCommand done";
     RG_DEBUG << "Clipboard contents";
     Segment* clipseg = c->getSingleSegment();
-    if (clipseg) clipseg->dumpSegment();
+    if (clipseg) RG_DEBUG << *clipseg;
     RG_DEBUG << "Clipboard contents done";
 
     macro->addCommand(new EraseCommand(*selection));
@@ -5224,6 +5224,9 @@ NotationView::slotMagicLayer()
         RG_WARNING << "NotationView: new layer not found";
         return;
     }
+    RG_DEBUG << "newLayer";
+    RG_DEBUG << *newLayer;
+    RG_DEBUG << "newLayer end";
     m_segments.push_back(newLayer);
 
     // re-invoke setSegments with the amended m_segments

--- a/src/gui/editors/notation/NotationView.cpp
+++ b/src/gui/editors/notation/NotationView.cpp
@@ -5148,7 +5148,7 @@ NotationView::slotAddLayer()
     CommandHistory::getInstance()->addCommand(command);
 
     // get the pointer to the segment we just created and add it to m_segments
-    Segment* newLayer = comp.getSegmentByBrand("Added Layer");
+    Segment* newLayer = comp.getSegmentByMarking("Added Layer");
     if (! newLayer) {
         RG_WARNING << "NotationView: new layer not found";
         return;
@@ -5161,7 +5161,7 @@ NotationView::slotAddLayer()
     // make the new segment active immediately
     NotationScene *scene = m_notationWidget->getScene();
     NotationStaff* newLayerStaff =
-        scene->getStaffBySegmentBrand("Added Layer");
+        scene->getStaffBySegmentMarking("Added Layer");
     if (! newLayerStaff) {
         RG_WARNING << "NotationView: new layer staff not found";
         return;
@@ -5202,8 +5202,7 @@ NotationView::slotMagicLayer()
     macro->addCommand(new EraseCommand(*selection));
 
     // use overlay paste to avoid checking for space; paste to new
-    // "layer" identify the layer with the segment brand. Initially
-    // provide the current segment in the paste command
+    // "layer" identify the layer with the segment marking.
     PasteEventsCommand::PasteType type = PasteEventsCommand::NoteOverlay;
     macro->addCommand(new PasteEventsCommand(*currentSegment, "Added Layer", c,
                                              insertionTime, type, comp));
@@ -5213,7 +5212,7 @@ NotationView::slotMagicLayer()
     CommandHistory::getInstance()->addCommand(macro);
 
     // get the pointer to the segment we just created and add it to m_segments
-    Segment* newLayer = comp.getSegmentByBrand("Added Layer");
+    Segment* newLayer = comp.getSegmentByMarking("Added Layer");
     if (! newLayer) {
         RG_WARNING << "NotationView: new layer not found";
         return;
@@ -5225,7 +5224,8 @@ NotationView::slotMagicLayer()
 
     // make the new segment active immediately
     NotationScene *scene = m_notationWidget->getScene();
-    NotationStaff* newLayerStaff = scene->getStaffBySegmentBrand("Added Layer");
+    NotationStaff* newLayerStaff =
+        scene->getStaffBySegmentMarking("Added Layer");
     if (! newLayerStaff) {
         RG_WARNING << "NotationView: new layer staff not found";
         return;

--- a/src/gui/editors/notation/NotationView.cpp
+++ b/src/gui/editors/notation/NotationView.cpp
@@ -5200,6 +5200,12 @@ NotationView::slotMagicLayer()
     CopyCommand *cc = new CopyCommand(*selection, c);
     cc->execute();
 
+    RG_DEBUG << "CopyCommand done";
+    RG_DEBUG << "Clipboard contents";
+    Segment* clipseg = c->getSingleSegment();
+    if (clipseg) clipseg->dumpSegment();
+    RG_DEBUG << "Clipboard contents done";
+
     macro->addCommand(new EraseCommand(*selection));
 
     // use overlay paste to avoid checking for space; paste to new

--- a/src/gui/editors/notation/NotationView.cpp
+++ b/src/gui/editors/notation/NotationView.cpp
@@ -5142,73 +5142,55 @@ NotationView::slotAddLayer()
     // wings.
     slotSetNoteRestInserter();
 
-    AddLayerCommand *command = new AddLayerCommand(getCurrentSegment(), getDocument()->getComposition());
+    Composition& comp = getDocument()->getComposition();
+    AddLayerCommand *command = new AddLayerCommand(getCurrentSegment(),
+                                                   comp);
     CommandHistory::getInstance()->addCommand(command);
 
     // get the pointer to the segment we just created and add it to m_segments
-    m_segments.push_back(command->getSegment());
-
+    Segment* newLayer = comp.getSegmentByBrand("Added Layer");
+    if (! newLayer) {
+        RG_WARNING << "NotationView: new layer not found";
+        return;
+    }
+    m_segments.push_back(newLayer);
+    
     // re-invoke setSegments with the amended m_segments
     setWidgetSegments();
-
-    // try to make the new segment active immediately
-    slotCurrentSegmentNext();
-
+    
+    // make the new segment active immediately
+    NotationScene *scene = m_notationWidget->getScene();
+    NotationStaff* newLayerStaff =
+        scene->getStaffBySegmentBrand("Added Layer");
+    if (! newLayerStaff) {
+        RG_WARNING << "NotationView: new layer staff not found";
+        return;
+    }
+    
+    setCurrentStaff(newLayerStaff);
+    slotEditSelectWholeStaff();
+    
     enterActionState("have_multiple_staffs");
 
-    // Undoing this goes kaboom bigtime.  What to do about that?  Make the
-    // command's undo emit a signal or something?  The notation widget needs to
-    // pick up the change and reboot itself again on the smaller set of
-    // segments, or at least close gracefully instead of crashing, the way it
-    // does when you undo the creation of a segment that was displayed in this
-    // view.
-    //
-    // I suppose it would be most ideal to have some mechanism in place whereby
-    // undoing segment creation in general triggered successive calls to
-    // setSegments() until there was only one segment left, and then we'd blink
-    // out of existence only after undoing that final one in a multi-segment
-    // context.
 }
 
 void
 NotationView::slotMagicLayer()
 {
-    // grab selection; else abort cleanly
     EventSelection *selection = getSelection();
     if (!selection) return;
 
     // switch to the pencil, as in slotAddLayer
     slotSetNoteRestInserter();
 
+    Segment* currentSegment = getCurrentSegment();
+
     MacroCommand *macro = new MacroCommand(tr("New Layer from Selection"));
 
+    Composition& comp = getDocument()->getComposition();
     // make a new "layer" segment
-    AddLayerCommand *command = new AddLayerCommand(getCurrentSegment(), getDocument()->getComposition());
-    command->execute();
-
-    // Not sure how to handle this:  We have to execute() here to get the
-    // segment created for pasting, but if we do that, the command executes a
-    // second time later on, and you end up with two new segments, one of which
-    // is empty...  The only way I see to avoid that is to execute here, and
-    // skip adding this to the MacroCommand, which means if you undo this
-    // operation, it won't be clean.  The only alternative I can think of is to
-    // add a series of commands to the stack, so one operation requires multiple
-    // undos to reverse.  I don't like that either.  Meh.  
-//    macro->addCommand(command);
-
-    // get the new segment we just created; abort if there is no new segment or
-    // if it is exactly the same as the current segment, which means new segment
-    // creation failed
-    Segment *newLayer = command->getSegment();
-    if (!newLayer || newLayer == getCurrentSegment()) {
-        RG_DEBUG << "NotationView::slotMagicLayer(): newLayer: " 
-                 << newLayer
-                 << " currentSegment: "
-                 << getCurrentSegment()
-                 << " aborting!" << endl;
-        delete macro;
-        return;
-    }
+    AddLayerCommand *command = new AddLayerCommand(currentSegment, comp);
+    macro->addCommand(command);
 
     // cut the selected events from the parent segment
     timeT insertionTime = selection->getStartTime();
@@ -5219,27 +5201,38 @@ NotationView::slotMagicLayer()
 
     macro->addCommand(new EraseCommand(*selection));
 
-    // use overlay paste to avoid checking for space; paste to new "layer" 
+    // use overlay paste to avoid checking for space; paste to new
+    // "layer" identify the layer with the segment brand. Initially
+    // provide the current segment in the paste command
     PasteEventsCommand::PasteType type = PasteEventsCommand::NoteOverlay;
-    macro->addCommand(new PasteEventsCommand(*newLayer, c, insertionTime, type));
+    macro->addCommand(new PasteEventsCommand(*currentSegment, "Added Layer", c,
+                                             insertionTime, type, comp));
     
     delete c;
 
     CommandHistory::getInstance()->addCommand(macro);
 
-    // normalize rests to clean up the weird double whole rest problem
-    newLayer->normalizeRests(newLayer->getStartTime(), newLayer->getEndTime());
-
     // get the pointer to the segment we just created and add it to m_segments
+    Segment* newLayer = comp.getSegmentByBrand("Added Layer");
+    if (! newLayer) {
+        RG_WARNING << "NotationView: new layer not found";
+        return;
+    }
     m_segments.push_back(newLayer);
 
     // re-invoke setSegments with the amended m_segments
     setWidgetSegments();
 
-    // try to make the new segment active immediately
-    // ??? This doesn't work consistently.  Need something better.
-    //     We have newLayer.  Can we just make that the selection?
-    slotCurrentSegmentNext();
+    // make the new segment active immediately
+    NotationScene *scene = m_notationWidget->getScene();
+    NotationStaff* newLayerStaff = scene->getStaffBySegmentBrand("Added Layer");
+    if (! newLayerStaff) {
+        RG_WARNING << "NotationView: new layer staff not found";
+        return;
+    }
+
+    setCurrentStaff(newLayerStaff);
+    slotEditSelectWholeStaff();
 
     enterActionState("have_multiple_staffs");
 }

--- a/src/gui/editors/notation/NotationView.h
+++ b/src/gui/editors/notation/NotationView.h
@@ -84,6 +84,11 @@ public:
     // Unadopt a segment that we previously adopted.
     void unadoptSegment(Segment *s);
 
+    // Adopt a segment that does live in Composition.
+    void adoptCompositionSegment(Segment *s);
+    // Unadopt a segment that we previously adopted.
+    void unadoptCompositionSegment(Segment *s);
+
 signals:
     void play();
     void stop();

--- a/src/gui/editors/notation/NoteRestInserter.cpp
+++ b/src/gui/editors/notation/NoteRestInserter.cpp
@@ -238,6 +238,10 @@ void NoteRestInserter::ready()
 
 void NoteRestInserter::stow()
 {
+    // This method is called if a segment has vanished. Clear
+    // m_clickStaff in case it is no longer valid
+    m_clickStaff = nullptr;
+
     // Fix bug #1528: NotationScene::clearPreviewNote() crash
     // This is a hack to avoid calling stow() twice, which causes this crash
     // when notation scene has been removed before the second call to stow().
@@ -548,6 +552,17 @@ bool
 NoteRestInserter::computeLocationAndPreview(const NotationMouseEvent *e,
                                             bool play)
 {
+    // check for valid staffs
+    std::vector<NotationStaff *>* allStaffs = m_scene->getStaffs();
+    std::vector<NotationStaff *>::iterator staffIter =
+        std::find(allStaffs->begin(), allStaffs->end(), e->staff);
+    if (staffIter == allStaffs->end()) return false;
+    if (m_clickStaff != nullptr) {
+        staffIter =
+            std::find(allStaffs->begin(), allStaffs->end(), m_clickStaff);
+        if (staffIter == allStaffs->end()) return false;
+    }
+    
     if (!e->staff || !e->element) {
         NOTATION_DEBUG << "computeLocationAndPreview: staff and/or element not supplied";
         clearPreview();


### PR DESCRIPTION
OK - this turned out to be more difficult than I thought (it usually does!)

The main problem is getting undo to work properly
My first approach was to use the Segment runtime id to identify the next segment to be created. Unfortunately segments are always being created and destroyed and this approach failed.

So I invented a segment "marking" - it is possible to set a marking on a segment (unique in the composition). The AddLayerCommand puts a marking on the new segment it creates so it can be accessed later.

To use this in the paste command it was necessary to change BasicCommand to allow for creation of the command before the segment is created.

I have added some debug output but it is turned off in the committed version.

I consider this change experimental. If you want something done differently please say so.

Also - not quite finished - it would be nice if on redo in the notation editor the layer is re-added to the notation editor. Maybe something like AdoptSegmentCommand ? ...