### PR TITLE
move editor window title logic to base class

### DIFF
--- a/src/gui/editors/eventlist/EventView.cpp
+++ b/src/gui/editors/eventlist/EventView.cpp
@@ -1642,34 +1642,19 @@ EventView::updateWindowTitle(bool m)
                        .arg(strtoqstr(m_segments[0]->getLabel())));
 
 
-    } else if (m_segments.size() == 1) {
-
-        // Fix bug #3007112
-        if (!m_segments[0]->getComposition()) {
-            // The segment is no more in the composition.
-            // Nothing to edit : close the editor.
-            close();
-            return;
-        }
-        
-        TrackId trackId = m_segments[0]->getTrack();
-        Track *track =
-            m_segments[0]->getComposition()->getTrackById(trackId);
-
-        int trackPosition = -1;
-        if (track)
-            trackPosition = track->getPosition();
-
-        setWindowTitle(tr("%1%2 - Segment Track #%3 - Event List")
-                       .arg(indicator)
-                       .arg(getDocument()->getTitle())
-                       .arg(trackPosition + 1));
-
     } else {
-
-        setWindowTitle(tr("%1%2 - %3 Segments - Event List")
-                       .arg(getDocument()->getTitle())
-                       .arg(m_segments.size()));
+        if (m_segments.size() == 1) {
+            
+            // Fix bug #3007112
+            if (!m_segments[0]->getComposition()) {
+                // The segment is no more in the composition.
+                // Nothing to edit : close the editor.
+                close();
+                return;
+            }
+        }
+        QString view = tr("Event List");
+        setWindowTitle(getTitle(view));
     }
 
     setWindowIcon(IconLoader::loadPixmap("window-eventlist"));

--- a/src/gui/editors/matrix/MatrixView.cpp
+++ b/src/gui/editors/matrix/MatrixView.cpp
@@ -299,9 +299,8 @@ MatrixView::slotSceneDeleted()
 }
 
 void
-MatrixView::slotUpdateWindowTitle(bool m)
+MatrixView::slotUpdateWindowTitle(bool)
 {
-    QString indicator = (m ? "*" : "");
     // Set client label
     //
     QString view = tr("Matrix");
@@ -310,52 +309,7 @@ MatrixView::slotUpdateWindowTitle(bool m)
 
     if (m_segments.empty()) return;
 
-    if (m_segments.size() == 1) {
-
-        TrackId trackId = m_segments[0]->getTrack();
-        Track *track =
-            m_segments[0]->getComposition()->getTrackById(trackId);
-
-        int trackPosition = -1;
-        if (track)
-            trackPosition = track->getPosition();
-
-        QString segLabel = strtoqstr(m_segments[0]->getLabel());
-        if (segLabel.isEmpty()) {
-            segLabel = " ";
-        } else {
-            segLabel = QString(" \"%1\" ").arg(segLabel);
-        }
-
-        QString trkLabel = strtoqstr(track->getLabel());
-        if (trkLabel.isEmpty() || trkLabel == tr("<untitled>")) {
-            trkLabel = " ";
-        } else {
-            trkLabel = QString(" \"%1\" ").arg(trkLabel);
-        }
-
-        setWindowTitle(tr("%1%2 - Segment%3Track%4#%5 - %6")
-                      .arg(indicator)
-                      .arg(getDocument()->getTitle())
-                      .arg(segLabel)
-                      .arg(trkLabel)
-                      .arg(trackPosition + 1)
-                      .arg(view));
-
-    } else if (m_segments.size() == getDocument()->getComposition().getNbSegments()) {
-
-        setWindowTitle(tr("%1%2 - All Segments - %3")
-                      .arg(indicator)
-                      .arg(getDocument()->getTitle())
-                      .arg(view));
-
-    } else {
-
-        setWindowTitle(tr("%1%2 - %n Segment(s) - %3", "", m_segments.size())
-                      .arg(indicator)
-                      .arg(getDocument()->getTitle())
-                      .arg(view));
-    }
+    setWindowTitle(getTitle(view));
 
     setWindowIcon(IconLoader::loadPixmap("window-matrix"));
 }

--- a/src/gui/editors/notation/NotationView.cpp
+++ b/src/gui/editors/notation/NotationView.cpp
@@ -3831,10 +3831,8 @@ NotationView::slotRegenerateScene()
 }
 
 void
-NotationView::slotUpdateWindowTitle(bool m)
+NotationView::slotUpdateWindowTitle(bool)
 {
-    QString indicator = (m ? "*" : "");
-
     if (m_segments.empty()) return;
 
     // Scene may be empty and the editor is about to be closed,
@@ -3844,34 +3842,8 @@ NotationView::slotUpdateWindowTitle(bool m)
     // In such a case, don't do anything (to avoid a crash).
     if (m_notationWidget->getScene()->isSceneEmpty()) return;
 
-    if (m_segments.size() == 1) {
-
-        TrackId trackId = m_segments[0]->getTrack();
-        Track *track =
-            m_segments[0]->getComposition()->getTrackById(trackId);
-
-        int trackPosition = -1;
-        if (track)
-            trackPosition = track->getPosition();
-        //    RG_DEBUG << std::endl << std::endl << "DEBUG TITLE BAR: " << getDocument()->getTitle() << std::endl << std::endl << std::endl;
-        setWindowTitle(tr("%1%2 - Segment Track #%3 - Notation")
-                      .arg(indicator)
-                      .arg(getDocument()->getTitle())
-                      .arg(trackPosition + 1));
-
-    } else if (m_segments.size() == getDocument()->getComposition().getNbSegments()) {
-
-        setWindowTitle(tr("%1%2 - All Segments - Notation")
-                      .arg(indicator)
-                      .arg(getDocument()->getTitle()));
-
-    } else {
-
-        setWindowTitle(tr("%1%2 - %n Segment(s) - Notation", "", m_segments.size())
-                    .arg(indicator)
-                    .arg(getDocument()->getTitle()));
-
-    }
+    QString view = tr("Notation");
+    setWindowTitle(getTitle(view));
 }
 
 void 

--- a/src/gui/general/EditViewBase.cpp
+++ b/src/gui/general/EditViewBase.cpp
@@ -338,4 +338,56 @@ EditViewBase::handleEventRemoved(Event */* event */)
 {
 }
 
+QString
+EditViewBase::getTitle(const QString& view)
+{
+    QString title;
+    QString indicator = (m_doc->isModified() ? "*" : "");
+    if (m_segments.size() == 1) {
+        
+        TrackId trackId = m_segments[0]->getTrack();
+        Track *track =
+            m_segments[0]->getComposition()->getTrackById(trackId);
+        
+        int trackPosition = -1;
+        if (track)
+            trackPosition = track->getPosition();
+        
+        QString segLabel = strtoqstr(m_segments[0]->getLabel());
+        if (segLabel.isEmpty()) {
+            segLabel = " ";
+        } else {
+            segLabel = QString(" \"%1\" ").arg(segLabel);
+        }
+        
+        QString trkLabel = strtoqstr(track->getLabel());
+        if (trkLabel.isEmpty() || trkLabel == tr("<untitled>")) {
+            trkLabel = " ";
+        } else {
+            trkLabel = QString(" \"%1\" ").arg(trkLabel);
+        }
+        title = tr("%1%2 - Segment%3Track%4#%5 - %6")
+            .arg(indicator)
+            .arg(getDocument()->getTitle())
+            .arg(segLabel)
+            .arg(trkLabel)
+            .arg(trackPosition + 1)
+            .arg(view);
+    } else if (m_segments.size() ==
+               getDocument()->getComposition().getNbSegments()) {
+        title = tr("%1%2 - All Segments - %3")
+            .arg(indicator)
+            .arg(getDocument()->getTitle())
+            .arg(view);
+    } else {
+        title = tr("%1%2 - %3 Segment(s) - %4")
+            .arg(indicator)
+            .arg(getDocument()->getTitle())
+            .arg(m_segments.size())
+            .arg(view);
+    }
+    
+    return title;
+}
+
 }

--- a/src/gui/general/EditViewBase.h
+++ b/src/gui/general/EditViewBase.h
@@ -230,6 +230,9 @@ protected:
     void setConfigDialogPageIndex(int p) { m_configDialogPageIndex = p; }
     int getConfigDialogPageIndex()       { return m_configDialogPageIndex; }
 
+    /// form a suitable title string for the window
+    QString getTitle(const QString& view);
+
     RosegardenDocument* m_doc;
 
     /// The Segment(s) that are being edited.


### PR DESCRIPTION
Each editor has its own (slightly different) logic for setting the window title.
I have moved the logic to the base class (EditViewBase) so the window titles should be consistent.